### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,56 +1,61 @@
 <h1 align='center'>
 <samp>Bypass Cloudflare for GitHub Action</samp>
 </h1>
-
 <p align='center'>
   <samp>Never receive 403 Forbidden from Cloudflare again.</samp>
 </p>
 
-Requests from github action server to a Cloudflare proxied host may be blocked by [Cloudflare's Web Application Firewall(WAF)](https://developers.cloudflare.com/support/troubleshooting/http-status-codes/4xx-client-error/) or [Bot Fight Mode](https://developers.cloudflare.com/bots/get-started/free/).
-
+Requests from GitHub Action servers to a Cloudflare proxied host may be blocked by [Cloudflare's Web Application Firewall(WAF)](https://developers.cloudflare.com/support/troubleshooting/http-status-codes/4xx-client-error/) or [Bot Fight Mode](https://developers.cloudflare.com/bots/get-started/free/).
 This action automatically adds the public IP of the GitHub Action runner to Cloudflare's firewall [IP Access rules](https://developers.cloudflare.com/waf/tools/ip-access-rules/).
 
 ## Features
-
 - Automatically retrieves the public IP of the GitHub Action runner.
 - Adds the runner's IP to Cloudflare's firewall access rules.
 - Waits for the IP to appear in Cloudflare's access rules.
 - Cleans up by removing the IP from Cloudflare's access rules after the job is complete.
 
 ## Inputs
-
-| Input        | Description        | Required |
-| ------------ | ------------------ | -------- |
-| `cf_zone_id` | Cloudflare Zone ID | true     |
-| `cf_api_key` | Cloudflare API Key | true     |
+| Input        | Description                | Required |
+| ------------ | -------------------------- | -------- |
+| `cf_zone_id` | Cloudflare Zone ID         | true     |
+| `cf_api_token` | Cloudflare API Token     | true     |
 
 ## Outputs
-
 | Output    | Description                       |
 | --------- | --------------------------------- |
 | `rule_id` | The ID of the created access rule |
 
 ## Usage
-
 To use this action, create a workflow in your repository's `.github/workflows` directory. Below is an example workflow file:
 
 ```yaml
 name: Bypass Cloudflare for API Access
-
 on: [push]
-
 jobs:
   manage-ip-whitelist:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
-
       - name: Bypass Cloudflare for GitHub Action
         uses: xiaotianxt/bypass-cloudflare-for-github-action@v1.0.0
         with:
           cf_zone_id: ${{ secrets.CF_ZONE_ID }}
-          cf_api_key: ${{ secrets.CF_API_KEY }}
-
+          cf_api_token: ${{ secrets.CF_API_TOKEN }}
       - name: Send request to Cloudflare-protected server
         run: curl https://example.com/api
+```
+
+## Important Note
+This action requires a Cloudflare API Token, not the Global API Key. To create an API token:
+
+1. Log in to the Cloudflare dashboard.
+2. Go to "My Profile" > "API Tokens".
+3. Click "Create Token".
+4. Use the "Edit zone DNS" template or create a custom token with the following permissions:
+   - Zone > Firewall Services > Edit
+   - Zone > DNS > Edit (if needed)
+5. Set the token to access the specific zone you're working with.
+6. Create the token and save it securely.
+
+Remember to add your Cloudflare Zone ID and the new API Token to your GitHub repository secrets as `CF_ZONE_ID` and `CF_API_TOKEN` respectively.

--- a/action.yaml
+++ b/action.yaml
@@ -7,8 +7,8 @@ inputs:
   cf_zone_id:
     description: "Cloudflare Zone ID"
     required: true
-  cf_api_key:
-    description: "Cloudflare API Key"
+  cf_api_token:
+    description: "Cloudflare API Token"
     required: true
 outputs:
   rule_id:
@@ -24,7 +24,6 @@ runs:
         result=$(curl https://ipinfo.io/json)
         ip=$(echo $result | jq -r '.ip')
         echo "public_ip=$ip" >> $GITHUB_ENV
-
     - name: Make CF API request and extract Rules ID
       shell: bash
       id: extract_id
@@ -33,14 +32,13 @@ runs:
         response=$(curl --request POST \
           --url https://api.cloudflare.com/client/v4/zones/${{ inputs.cf_zone_id }}/firewall/access_rules/rules \
           --header 'Content-Type: application/json' \
-          --header 'Authorization: Bearer ${{ inputs.cf_api_key }}' \
+          --header 'Authorization: Bearer ${{ inputs.cf_api_token }}' \
           --data '{"mode":"whitelist","configuration":{"target":"ip","value":"'"$ipv4"'"},"notes":"Github Action IP for API ACCESS"}')
         echo "Response: $response"
         id=$(echo $response | jq -r '.result.id')
         echo "Extracted ID: $id"
         echo "rule_id=$id" >> $GITHUB_ENV
         echo "rule_id=$id" >> $GITHUB_OUTPUT
-
     - name: Wait for IP to appear in Access Rules
       shell: bash
       id: wait_for_ip
@@ -54,7 +52,7 @@ runs:
           response=$(curl --request GET \
             --url https://api.cloudflare.com/client/v4/zones/${{ inputs.cf_zone_id }}/firewall/access_rules/rules \
             --header 'Content-Type: application/json' \
-            --header 'Authorization: Bearer ${{ inputs.cf_api_key }}')
+            --header 'Authorization: Bearer ${{ inputs.cf_api_token }}')
           ip_in_rules=$(echo $response | jq -r --arg ip "$ipv4" '[.result[] | select(.configuration.value == $ip)] | length')
           if [ "$ip_in_rules" -gt 0 ]; then
             echo "IP $ipv4 is now whitelisted."
@@ -69,12 +67,10 @@ runs:
           echo "Failed to verify IP $ipv4 in access rules after $max_retries retries."
           exit 1
         fi
-
     - name: Delete IP from Access Rules
       uses: gacts/run-and-post-run@v1
       with:
         post: |
           rule_id=${{ env.rule_id }}
           echo "Deleting rule with ID: $rule_id"
-          curl --request DELETE --url https://api.cloudflare.com/client/v4/zones/${{ inputs.cf_zone_id }}/firewall/access_rules/rules/$rule_id --header 'Content-Type: application/json' --header 'Authorization: Bearer ${{ inputs.cf_api_key }}' || exit 1
-
+          curl --request DELETE --url https://api.cloudflare.com/client/v4/zones/${{ inputs.cf_zone_id }}/firewall/access_rules/rules/$rule_id --header 'Content-Type: application/json' --header 'Authorization: Bearer ${{ inputs.cf_api_token }}' || exit 1


### PR DESCRIPTION
This pull request updates the README.md file to provide clearer and more accurate documentation for the "Bypass Cloudflare for GitHub Action". Key changes include:

1. Replaced references to "cf_api_key" with "cf_api_token" to reflect the correct authentication method.
2. Updated the example usage to show the correct secret name (CF_API_TOKEN).
3. Added an important note explaining the need for a Cloudflare API Token instead of the Global API Key.
4. Included step-by-step instructions on how to create the required API Token in Cloudflare.
5. Clarified the permissions needed for the API Token.

These changes aim to improve user understanding and reduce potential setup issues when using this GitHub Action.