### PR TITLE
Update IP querying service

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -20,8 +20,7 @@ runs:
       shell: bash
       id: get_ip
       run: |
-        result=$(curl https://ipinfo.io/json)
-        ip=$(echo $result | jq -r '.ip')
+        ip=$(curl -s https://api64.ipify.org)
         echo "public_ip=$ip" >> $GITHUB_ENV
     - name: Check Existing CF IP List (Lists API)
       shell: bash


### PR DESCRIPTION
The step where we query the GitHub Runner's public IP address works most of the time, but sometimes returns null value.

It turns out that the service currently used to query GitHub Runner's public IP address (`ipinfo.io`) is rate limited to 1,000 unauthenticated requests, per day per IP address ([source](https://ipinfo.io/faq/article/134-what-is-the-difference-between-using-the-authenticated-free-plan-and-just-the-public-api-with-no-account)).

Suggesting to replace this with `api64.ipify.org`, which is not rate-limited, and can handle both ipv4 and ipv6.